### PR TITLE
Fix diagram with unknown elements aren't drawn

### DIFF
--- a/modules/flowable-ui-admin/flowable-ui-admin-app/src/main/webapp/display/displaymodel.html
+++ b/modules/flowable-ui-admin/flowable-ui-admin-app/src/main/webapp/display/displaymodel.html
@@ -291,11 +291,13 @@
 				    for (var i = 0; i < modelElements.length; i++)
 				    {
 				    	var element = modelElements[i];
-				    	//try {
+				    	try {
 				    		//console.log(element.type);
 				    		var drawFunction = eval("_draw" + element.type);
 				    		drawFunction(element);
-				    	//} catch(err) {console.log(err);}
+				    	} catch (err) {
+				    		console.warn(err);
+				    	}
 				    }
 				    
 				    if (data.flows)


### PR DESCRIPTION
When I try display a process definition diagram with unknown elements (data object) with Flowable Admin UI, the diagram is not drawn at all.

With this fix, only the drawable elements are drawn and a warning is shown in the console for each element that can't be drawn.